### PR TITLE
fix: use BASE_URL for alpaca image paths

### DIFF
--- a/src/components/AlpacaBuilder.vue
+++ b/src/components/AlpacaBuilder.vue
@@ -24,7 +24,7 @@
           width="500"
           v-for="(value, choice) in alpaca"
           :key="choice"
-          :src="`/alpaca/${choice}/${value}.png`"
+          :src="`${baseUrl}alpaca/${choice}/${value}.png`"
         />
       </div>
     </div>
@@ -147,6 +147,7 @@ export default {
     var selectedChoiceName = "backgrounds";
 
     return {
+      baseUrl: import.meta.env.BASE_URL,
       configuration: Configuration,
       alpaca: Alpaca,
       selectedChoiceName: selectedChoiceName,


### PR DESCRIPTION
Fixes images not loading on GitHub Pages.\n\nAbsolute paths like `/alpaca/...` break when the site is served under a subpath (`/avatar-generator/`). This uses Vite's `import.meta.env.BASE_URL` to prefix image paths correctly in both dev and production.